### PR TITLE
Use correct fallback codepage

### DIFF
--- a/src/zinolib/ritz.py
+++ b/src/zinolib/ritz.py
@@ -98,13 +98,13 @@ notifierEntry = NamedTuple("notifierEntry", [("id", int), ("type", str), ("info"
 zinoDataEntry = NamedTuple("zinoDataEntry", [("data", str), ("header", str)])
 
 
-def windows_codepage_cp1251(error):
-    """Windows Codepage 1251 decoder fallback
+def windows_codepage_cp1252(error):
+    """Windows Codepage 1252 decoder fallback
 
     This function could be used as a failback for UnicodeEncodeError to fail
-    back to windows codepage 1251 decoding when eg. utf-8 failes
+    back to windows codepage 1252 decoding when eg. utf-8 failes
 
-    All valid windows codepage 1251 elements will be returned with their
+    All valid windows codepage 1252 elements will be returned with their
     representative unicode characters and failes back to unicode unknown char
     when no valid character is found
 
@@ -116,9 +116,9 @@ def windows_codepage_cp1251(error):
         raise error
 
     # 0xFFFD is the unicode char for illegal character.
-    # these characters are not an valid printable cp1251 character
+    # these characters are not an valid printable cp1252 character
 
-    cp1251_map = [
+    cp1252_map = [
         0x20AC, 0xFFFD, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021, #0x80-0x87
         0x02c6, 0x2030, 0x0160, 0x2039, 0x0152, 0xFFFD, 0x017d, 0xFFFD, #0x88-0x8F
         0xFFFD, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014, #0x90-0x97
@@ -130,8 +130,8 @@ def windows_codepage_cp1251(error):
         byte = error.object[i]
 
         if byte >= 0x80 and byte <= 0x9F:
-            # We try to use windows codepage 1251 on this char
-            result.append(chr(cp1251_map[byte - 0x80]))
+            # We try to use windows codepage 1252 on this char
+            result.append(chr(cp1252_map[byte - 0x80]))
 
         else:
             # This looks like a valid latin-1 char
@@ -141,7 +141,7 @@ def windows_codepage_cp1251(error):
     return "".join(result), error.end
 
 
-codecs.register_error("windows_codepage_cp1251", windows_codepage_cp1251)
+codecs.register_error("windows_codepage_cp1252", windows_codepage_cp1252)
 
 
 class caseState(enum.Enum):
@@ -425,7 +425,7 @@ class ritz:
                 )
             logger.debug("recv: %s" % data.__repr__())
 
-            buffer += data.decode("UTF-8", errors="windows_codepage_cp1251")
+            buffer += data.decode("UTF-8", errors="windows_codepage_cp1252")
 
             if not header:
                 if buffer.find(delim) != -1:


### PR DESCRIPTION
Windows codepage 1251 covers *cyrillic* and has been fixed to windows codepage 1252, which is a superset of iso-8859-1 that needs adapting to UTF-8.