### PR TITLE
Initialize ritz with default authenticated value

### DIFF
--- a/src/zinolib/ritz.py
+++ b/src/zinolib/ritz.py
@@ -351,6 +351,7 @@ class ritz:
 
         self._sock = None
         self.connStatus = False
+        self.authenticated = None
         self.server = server
         self.port = port
         self.timeout = timeout


### PR DESCRIPTION
Ritz class has property `authenticated` set to `True` or `False` only on some method calls. This leads to `AttributeError: 'ritz' object has no attribute 'authenticated'`  when checking its value before any of those methods are called. 