### PR TITLE
Fix parsing of garbage input to getlog

### DIFF
--- a/src/zinolib/controllers/zino1.py
+++ b/src/zinolib/controllers/zino1.py
@@ -397,7 +397,11 @@ class LogAdapter:
         log_list: List[LogDict] = []
         for row in log_data:
             timestamp, log = row.split(" ", 1)
-            dt = convert_timestamp(int(timestamp))
+            try:
+                timestamp = int(timestamp)
+            except ValueError as e:
+                raise RetryError('Zino 1 is flaking out, retry') from e
+            dt = convert_timestamp(timestamp)
             log_list.append({"date": dt, "log": log})
         return log_list
 

--- a/src/zinolib/ritz.py
+++ b/src/zinolib/ritz.py
@@ -86,7 +86,7 @@ from typing import NamedTuple, List, Tuple, Union
 import codecs
 import select
 
-from .config.tcl import parse_tcl_config
+from .config.tcl import parse_tcl_config  # noqa: F401 (used to be in this file)
 from .utils import windows_codepage_cp1252, generate_authtoken
 
 
@@ -260,7 +260,9 @@ class Case:
             return self.get_downtime()
         else:
             self.__getattribute__(name)
-            # raise AttributeError("%s instance of type %s has no attribute '%s'" % (self.__class__, self._attrs["type"], name))
+            # raise AttributeError(
+            #     "%s instance of type %s has no attribute '%s'" % (self.__class__, self._attrs["type"], name)
+            # )
         return self
 
     def __getitem__(self, key):

--- a/src/zinolib/utils.py
+++ b/src/zinolib/utils.py
@@ -75,7 +75,7 @@ def log_exception_with_params(logger, reraise=True, return_value=None):
             except Exception as e:
                 params = f'args={args} kwargs={kwargs}'
                 funcname = function.__name__
-                logger.exception(f'"{funcname}" failed with: {params}\n{e}')
+                logger.exception('"%s" failed with: %s\n%s', funcname, params, e)
                 if reraise:
                     raise
                 return return_value

--- a/src/zinolib/utils.py
+++ b/src/zinolib/utils.py
@@ -1,6 +1,5 @@
 import functools
 import hashlib
-from typing import Any
 
 
 __all__ = [


### PR DESCRIPTION
Closes #36

Sometimes, Zino 1 replies to `b'getlog'` with the output from `b'getattrs'`, this leads to an exception.

That exception is here replaced with a RetryError.