### PR TITLE
Fix parsing of garbage input to get_event_ids

### DIFF
--- a/src/zinolib/ritz.py
+++ b/src/zinolib/ritz.py
@@ -391,10 +391,10 @@ class ritz:
                         line, buffer = buffer.split(self.DELIMITER, 1)
                         rawh = line.split(" ", 1)  # ' ' is not a byte
                         header = (int(rawh[0]), rawh[1])
-                    except ValueError:
+                    except ValueError as e:
                         raise ProtocolError(
                             "Illegal response from server detected: %s" % repr(buffer)
-                        )
+                        ) from e
                     # header = line
                     # Crude error detection :)
                     if header[0] >= 500:


### PR DESCRIPTION
Depends on #44.

Handles the following exception better:

```
2024-01-24 11:52:01,670 ERROR howitz /../howitz/src/howitz/error_handlers.py:46:: An unexpected exception has occurred Illegal response from server detected: '1705928363 ifi2-gw5: port "et-0/1/6" ix 719 (UN000165, ifi2-hmg9, hmg9-gw1) changed state from up to up on 1705928245\r\n.\r\n'
Traceback (most recent call last):
  File "/../zinolib/src/zinolib/ritz.py", line 391, in _request
    header = (int(rawh[0]), rawh[1])
ValueError: invalid literal for int() with base 10: 'g9-gw1)'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/VENV/howitz/lib/python3.10/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/VENV/howitz/lib/python3.10/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/../howitz/src/howitz/endpoints.py", line 305, in poll_events
  File "/../howitz/src/howitz/endpoints.py", line 117, in poll_current_events
    current_app.logger.exception('Recurrent NotConnectedError %s', notConnErr)
  File "/../zinolib/src/zinolib/controllers/zino1.py", line 472, in get_events
    for event_id in self._event_adapter.get_event_ids(self.session.request):
  File "/../zinolib/src/zinolib/controllers/zino1.py", line 300, in get_event_ids
    return request.get_caseids()
  File "/../zinolib/src/zinolib/ritz.py", line 545, in get_caseids
    response = self._request(b"caseids")
  File "/../zinolib/src/zinolib/ritz.py", line 393, in _request
    raise ProtocolError(
zinolib.ritz.ProtocolError: Illegal response from server detected: '1705928363 ifi2-gw5: port "et-0/1/6" ix 719 (UN000165, ifi2-hmg9, hmg9-gw1) changed state from up to up on 1705928245\r\n.\r\n'
```

The ProtocolError is replaced with a RetryError.