### PR TITLE
Catch BrokenPipeError on socket send

### DIFF
--- a/src/zinolib/ritz.py
+++ b/src/zinolib/ritz.py
@@ -371,7 +371,10 @@ class ritz:
             delimiter = bytes(self.DELIMITER, 'ascii')
             if not command.endswith(delimiter):
                 command += delimiter
-            self._sock.send(command)
+            try:
+                self._sock.send(command)
+            except BrokenPipeError as e:
+                raise NotConnectedError(f'Lost connection to server: {e}') from e
         while data:
             try:
                 data = self._sock.recv(recv_buffer)


### PR DESCRIPTION
If we lose connection while sending data to the server, a BrokenPipeError is sent. It was uncaught.