### PR TITLE
Handle garbage admstate from server

### DIFF
--- a/src/zinolib/event_types.py
+++ b/src/zinolib/event_types.py
@@ -45,6 +45,13 @@ class AdmState(StrEnum):
     OPEN = "open"
     WAITING = "waiting"
     WORKING = "working"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value):
+        # Python 3.12: "if not value in cls:"
+        if not value in cls._value2member_map_:
+            return cls.UNKNOWN
 
 
 class FlapState(StrEnum):

--- a/tests/test_zinolib_controllers_zino1.py
+++ b/tests/test_zinolib_controllers_zino1.py
@@ -106,6 +106,18 @@ class Zino1EventManagerTest(unittest.TestCase):
         zino1 = FakeZino1EventManager.configure(None)
         return zino1
 
+    def test_create_event_from_id_receiving_garbage_admstate_is_safely_handled(self):
+        global raw_attrlist
+        zino1 = self.init_manager()
+        good_attrlist = raw_attrlist[:] # copy
+        try:
+            raw_attrlist[0] = "state: garbage admstate"
+            event = zino1.create_event_from_id(139110)
+            self.assertEqual(event.adm_state, AdmState.UNKNOWN)
+        finally:
+            # reset to known good attrlist for other tests
+            raw_attrlist = good_attrlist
+
     def test_create_event_from_id_may_get_garabage_data(self):
         def falsey(_):
             return False

--- a/tests/test_zinolib_event_types.py
+++ b/tests/test_zinolib_event_types.py
@@ -252,3 +252,15 @@ class EventManagerTest(unittest.TestCase):
         }]
         updated_event = event_manager.set_log_for_event(event, log_list)
         self.assertTrue(event_manager.events[event.id].log)
+
+
+class AdmStateTest(unittest.TestCase):
+
+    def test_golden_path(self):
+        for state in AdmState:
+            enum_state = AdmState(state)
+            self.assertEqual(enum_state.value, state)
+
+    def test_garbage_input_should_be_converted_to_UNKNOWN(self):
+        value = AdmState("random garbage")
+        self.assertEqual(value, AdmState.UNKNOWN)


### PR DESCRIPTION
Python 3.12 supports "value in EnumSubclass" in `_missing_` directly but the current fix also works for 3.12.