### PR TITLE
Upgrade codecov-action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,8 @@ jobs:
           reports/**/*
 
     - name: "Upload coverage to Codecov"
-      if: "github.repository_owner == 'Uninett'"
-      uses: codecov/codecov-action@v3
+      if: github.repository_owner == 'Uninett'
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for forks of public repos


### PR DESCRIPTION
`CODECOV_TOKEN` is also in the repository secrets.