### PR TITLE
Add method to determine whether event is down

### DIFF
--- a/src/zinolib/event_types.py
+++ b/src/zinolib/event_types.py
@@ -174,6 +174,9 @@ class Event(BaseModel):
         eventobj = subtype(**attrdict)
         return eventobj
 
+    def is_down(self):
+        raise NotImplementedError("Abstract method was called, can not calculate is_down status without event type.")
+
 
 EventType = TypeVar('EventType', bound=Event)
 EventOrId = Union[EventType, int]


### PR DESCRIPTION
As suggested by @hmpf in https://github.com/Uninett/Howitz/pull/81

> ...
> 
> Even better would be to have a method on each event-type that returns a bool if that event is considered "down".
> 
> ```
> if event.is_down():
>   if event.adm_state == AdmState.OPEN:
>     return 4
>   if event.adm_state in [AdmState.WORKING, AdmState.WAITING]:
>     return 3
> ```

