### PR TITLE
Run tests on pushes to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test zinolib
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
 
 jobs:


### PR DESCRIPTION
A classic copy and paste mistake from copying from Zino, which uses the "master" branch name instead... 
I noticed this when trying to check if the codecov uploading is working here, but noticed that it has not yet, which made me suspicious...