### PR TITLE
Raise NotConnectedError in UpdateHandler.check_connection

### DIFF
--- a/src/zinolib/controllers/zino1.py
+++ b/src/zinolib/controllers/zino1.py
@@ -157,6 +157,7 @@ class UpdateHandler:
         self.check_connection()
 
     def check_connection(self):
+        self.manager._verify_session()
         if self.manager.session.push._sock.fileno() >= 0:
             self._connected = True
             return True


### PR DESCRIPTION
… instead of AttributeError when something nasty has happened to the session object.

For first part of #68