### PR TITLE
Parse empty lines in history entries correctly

### DIFF
--- a/src/zinolib/ritz.py
+++ b/src/zinolib/ritz.py
@@ -144,6 +144,10 @@ def _decode_history(logarray):
     for log in logarray:
         if not log[0] == " ":
             # This is a header line
+            if curr:
+                # We've found a new header, append the current entry first
+                ret.append(curr)
+
             curr = {}
             curr["log"] = []
 
@@ -157,16 +161,14 @@ def _decode_history(logarray):
                 # this is a short system log
                 curr["log"] = []
                 curr["user"] = "system"  # re.match(".*\((\w+)\)$", header[1]).group(1)
-                ret.append(curr)
             else:
                 curr["user"] = header[1]
 
-        elif log == " ":
-            # End entry, empty line with one space
-            ret.append(curr)
         else:
             # Append log line
             curr["log"].append(log[1::])
+    if curr:
+        ret.append(curr)
     return ret
 
 

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -202,7 +202,7 @@ class DefaultTest(unittest.TestCase):
                     "date": datetime.datetime(2018, 10, 14, 11, 25, 23),
                     "header": "runarb",
                     "user": "runarb",
-                    "log": ["Testmelding ifra pyRitz"],
+                    "log": ["Testmelding ifra pyRitz", ""],
                 }
                 self.assertEqual(hist[1], test)
 

--- a/tests/test_ritz.py
+++ b/tests/test_ritz.py
@@ -1,6 +1,6 @@
 import unittest
 
-from zinolib.ritz import Case
+from zinolib.ritz import Case, _decode_history
 
 
 class CaseTest(unittest.TestCase):
@@ -27,3 +27,29 @@ class CaseTest(unittest.TestCase):
         with self.assertRaises(AttributeError) as cm:
             case.xux
         self.assertEqual(cm.exception.args[0], expected_msg)
+
+
+class DecodeHistoryTest(unittest.TestCase):
+    def test_when_entry_does_not_end_in_empty_line_it_should_not_be_ignored(self):
+        raw_history = [
+            "1753277115 state change embryonic -> open (monitor)",
+            "1753277215 ford",
+            " the world's about to end",
+            "1753277415 ford",
+            " time is an illusion,",
+            " lunchtime doubly so",
+            " ",
+        ]
+        history = _decode_history(raw_history)
+        self.assertEquals(len(history), 3, "Should have decoded 3 history entries")
+
+    def test_when_entry_contains_empty_lines_it_should_not_be_duplicated(self):
+        raw_history = [
+            "1753277415 ford",
+            " time is an illusion,",
+            " ",
+            " lunchtime doubly so",
+            " ",
+        ]
+        history = _decode_history(raw_history)
+        self.assertEquals(len(history), 1, "Should have decoded only 1 history entry")


### PR DESCRIPTION
This fixes #77 and adds regressions tests.

This targets the `stable/0.x` branch, because we need this bugfix to affect cuRitz, which only uses the stable branch.  When merged, it should be also be ported to the mainline and a `1.x` release (which is what Howitz and newer clients are using).
