### PR TITLE
Add automatic testing for Python 3.12 and move codecov upload to test workflow

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,4 +1,4 @@
-name: Publish test and coverage results
+name: Publish test results
 
 on:
   workflow_run:
@@ -8,19 +8,11 @@ on:
 
 jobs:
   publish-test-results:
-    name: "Publish test and coverage results"
+    name: "Publish test results"
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
 
     steps:
-      # Checking out the repo is necessary codecov/codecov-action@v7 to work properly
-      # Codecov requires source code to process the coverage file and generate coverage
-      # reports
-      - name: Checkout Code
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-
       - name: Download and Extract Artifacts
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -40,32 +32,3 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: "Test results"
           files: artifacts/**/*-results.xml
-
-      - name: Read PR number file
-        if: ${{ hashFiles('artifacts/extra/pr_number') != '' }}
-        run: |
-          pr_number=$(cat artifacts/extra/pr_number)
-          re='^[0-9]+$'
-          if [[ $pr_number =~ $re ]] ; then
-            echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
-          fi
-
-      - name: Read base SHA file
-        if: ${{ hashFiles('artifacts/extra/base_sha') != '' }}
-        run: |
-          base_sha=$(cat artifacts/extra/base_sha)
-          re='[0-9a-f]{40}'
-          if [[ $base_sha =~ $re ]] ; then
-            echo "BASE_SHA=$base_sha" >> $GITHUB_ENV
-          fi
-
-      - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v7
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          override_branch: ${{ github.event.workflow_run.head_branch}}
-          override_commit: ${{ github.event.workflow_run.head_sha}}
-          commit_parent: ${{ env.BASE_SHA }}
-          override_pr: ${{ env.PR_NUMBER }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,23 +48,10 @@ jobs:
         path: |
           reports/**/*
 
-  upload-pr-number-base-sha:
-    name: Save PR number and base SHA in artifact
-    runs-on: ubuntu-latest
-    if: ${{ github.event.number && always() }}
-    env:
-      PR_NUMBER: ${{ github.event.number }}
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
-    steps:
-      - name: Make PR number file
-        run: |
-          mkdir -p ./extra
-          echo $PR_NUMBER > ./extra/pr_number
-      - name: Make base SHA file
-        run: |
-          echo $BASE_SHA > ./extra/base_sha
-      - name: Upload PR number file and base SHA file
-        uses: actions/upload-artifact@v7
-        with:
-          name: extra
-          path: extra/
+    - name: "Upload coverage to Codecov"
+      if: github.repository_owner == 'Uninett'
+      uses: codecov/codecov-action@v7
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/tests/test_ritz.py
+++ b/tests/test_ritz.py
@@ -15,7 +15,7 @@ class DecodeHistoryTest(unittest.TestCase):
             " ",
         ]
         history = _decode_history(raw_history)
-        self.assertEquals(len(history), 3, "Should have decoded 3 history entries")
+        self.assertEqual(len(history), 3, "Should have decoded 3 history entries")
 
     def test_when_entry_contains_empty_lines_it_should_not_be_duplicated(self):
         raw_history = [
@@ -26,4 +26,4 @@ class DecodeHistoryTest(unittest.TestCase):
             " ",
         ]
         history = _decode_history(raw_history)
-        self.assertEquals(len(history), 1, "Should have decoded only 1 history entry")
+        self.assertEqual(len(history), 1, "Should have decoded only 1 history entry")


### PR DESCRIPTION
Since we're supporting Python 3.12 we should also test for it.

Codecov now supports tokenless upload for forks and changes done in #65 can be reverted again.